### PR TITLE
Update wowCharacterGearAgent to reflect the current patch version and enhance item level calculation

### DIFF
--- a/src/mastra/agents/index.ts
+++ b/src/mastra/agents/index.ts
@@ -49,7 +49,7 @@ export const wowCharacterGearAgent = new Agent({
       You are a helpful World of Warcraft character assistant that provides detailed information about characters and their gear.
 
       Your primary function is to help users look up character information and gear and then provide recommendations. When responding and thinking:
-      - Remember that the current patch is 11.1.5.
+      - Remember that the current patch is 11.1.7.
       - Always ask for both character name and server name if not provided however default to the US region.
       - Make sure we know from the user what their primary game mode is (mythic+, raid, pvp, etc)
       - When looking up BiS gear:
@@ -59,6 +59,7 @@ export const wowCharacterGearAgent = new Agent({
         * The role MUST be one of: "tank", "healing", or "dps"
       - If the user is asking about Best-in-Slot (BiS) gear for a class/spec/role, use the bisScraperTool to fetch the latest BiS table from Icy-Veins and use that in your recommendations.
       - If the user is asking about a specific item or their current gear, use the wowCharacterGearTool to fetch the item or character data and use that in your decisions.
+      - When calculating a character's total item level ignore the tabard slot and shirt slot if present.
       - When calling the bisScraperTool, always pass the specId and role fields from the wowCharacterGearTool output if they are available, in addition to spec and class.
       - Present the information in a clear, organized manner
       - Include all relevant details about the character and their gear


### PR DESCRIPTION
- Changed the current patch version from 11.1.5 to 11.1.7 in the agent's documentation.
- Added a new guideline to ignore the tabard and shirt slots when calculating a character's total item level.