### PR TITLE
Add comprehensive Vitest suite for Mastra tools and agent

### DIFF
--- a/tests/agent/e2e-agent.test.ts
+++ b/tests/agent/e2e-agent.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { wowCharacterGearAgent } from '../../src/mastra/agents';
+
+// Mock network-heavy tools inside the agent via module mocks
+vi.mock('../../src/mastra/tools', async (orig) => {
+  const actual = await (orig as any)();
+  return {
+    ...actual,
+    wowCharacterGearTool: {
+      id: 'get-wow-character-gear',
+      execute: vi.fn(async ({ context }) => ({
+        name: 'Bezvoker',
+        server: 'Korgath',
+        level: 80,
+        class: 'Evoker',
+        race: 'Dracthyr',
+        gender: 'Female',
+        guild: 'Test Guild',
+        spec: 'Devastation',
+        specId: 1467,
+        role: 'dps',
+        heroTalentTree: { id: 1, name: 'Scalecommander' },
+        gear: [ { slot: 'Head', name: 'Cowl of Tests', quality: 'Epic', itemLevel: 525 } ],
+      })),
+      inputSchema: { parse: (x: any) => x },
+      outputSchema: { parse: (x: any) => x },
+    },
+  };
+});
+
+// Avoid invoking MCP providers
+vi.mock('../../src/mastra/mcp', () => ({ mcp: { getTools: async () => ({}) } }));
+
+// Avoid model network calls by mocking the Agent's generate to just call tool directly when prompt contains a lookup intent
+vi.mock('@mastra/core/agent', async (orig) => {
+  const actual = await (orig as any)();
+  class FakeAgent extends actual.Agent {
+    async generate(message: string) {
+      if (/bezvoker/i.test(message) && /korgath/i.test(message)) {
+        const data = await (this as any).tools.wowCharacterGearTool.execute({ context: { characterName: 'bezvoker', serverName: 'korgath', region: 'us' } });
+        return { text: `Found ${data.name} on ${data.server} (${data.class} - ${data.spec}).` };
+      }
+      return { text: 'No-op' };
+    }
+  }
+  return { ...actual, Agent: FakeAgent };
+});
+
+describe('wowCharacterGearAgent e2e (mocked)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('answers a basic lookup for character "bezvoker" on "korgath"', async () => {
+    const result = await wowCharacterGearAgent.generate('Look up the character bezvoker on korgath');
+    expect(result.text).toMatch(/Bezvoker/);
+    expect(result.text).toMatch(/Korgath/);
+    expect(result.text).toMatch(/Evoker/);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,19 @@
+import { vi, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+
+// Set env for tests (no real secrets used)
+beforeAll(() => {
+  process.env.BLIZZARD_CLIENT_ID = process.env.BLIZZARD_CLIENT_ID || 'test-client-id';
+  process.env.BLIZZARD_CLIENT_SECRET = process.env.BLIZZARD_CLIENT_SECRET || 'test-client-secret';
+  process.env.MODEL_PROVIDER = process.env.MODEL_PROVIDER || 'openai';
+  process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || 'test-key';
+  process.env.OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o';
+  process.env.OPENAI_BASE_URL = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
+
+  // Prevent writing debug logs to the repository during tests
+  vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {} as any);
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});

--- a/tests/tools/bisScraperTool.test.ts
+++ b/tests/tools/bisScraperTool.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { bisScraperTool } from '../../src/mastra/tools/bisTool';
+import { fetch } from 'undici';
+
+vi.mock('undici', () => ({ fetch: vi.fn() }));
+
+function htmlWithHeaderAndTable() {
+  return `
+  <html>
+    <body>
+      <h2>Overall BiS Gear</h2>
+      <table>
+        <tr><th>Slot</th><th>Item</th></tr>
+        <tr><td>Head</td><td>Test Helm</td></tr>
+        <tr><td>Chest</td><td>Test Chest</td></tr>
+      </table>
+    </body>
+  </html>
+  `;
+}
+
+describe('bisScraperTool', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requires a role or specId that resolves to a role', async () => {
+    await expect(
+      bisScraperTool.execute({ context: { spec: 'Devastation', cls: 'Evoker', specId: '', role: '' } } as any)
+    ).rejects.toThrow(/Role could not be determined/);
+  });
+
+  it('auto-fills role from specId and scrapes table', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      text: async () => htmlWithHeaderAndTable(),
+    } as any);
+
+    const result = await bisScraperTool.execute({ context: { spec: 'Devastation', cls: 'Evoker', specId: '1467', role: '' } } as any);
+
+    expect(result.role).toBe('dps');
+    expect(result.bis).toEqual({ Head: 'Test Helm', Chest: 'Test Chest' });
+    expect(result.source).toContain('icy-veins.com');
+  });
+});

--- a/tests/tools/fetchUrlContentTool.test.ts
+++ b/tests/tools/fetchUrlContentTool.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { extract } from '@extractus/article-extractor';
+import { fetchUrlContentTool } from '../../src/mastra/tools';
+
+vi.mock('@extractus/article-extractor', () => ({
+  extract: vi.fn(),
+}));
+
+describe('fetchUrlContentTool', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns extracted content fields', async () => {
+    (extract as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      title: 'Title',
+      content: '<p>Hello</p>',
+      author: 'Author',
+      published: '2024-01-01',
+      url: 'https://example.com',
+    });
+
+    const result = await fetchUrlContentTool.execute({ context: { url: 'https://example.com' } } as any);
+
+    expect(result).toEqual({
+      title: 'Title',
+      content: '<p>Hello</p>',
+      author: 'Author',
+      published: '2024-01-01',
+      url: 'https://example.com',
+    });
+  });
+
+  it('gracefully handles extractor returning null/undefined', async () => {
+    (extract as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const result = await fetchUrlContentTool.execute({ context: { url: 'https://nope.com' } } as any);
+    expect(result).toEqual({ error: 'Could not extract content.' });
+  });
+});

--- a/tests/tools/webSearchTool.test.ts
+++ b/tests/tools/webSearchTool.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as googleSr from 'google-sr';
+import { webSearchTool } from '../../src/mastra/tools';
+
+vi.mock('google-sr', () => ({
+  search: vi.fn(),
+}));
+
+describe('webSearchTool', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns top N formatted results', async () => {
+    (googleSr.search as any).mockResolvedValue([
+      { title: 'A', link: 'https://a.com', description: 'a' },
+      { title: 'B', link: 'https://b.com', description: 'b' },
+      { title: 'C', link: 'https://c.com', description: 'c' },
+    ]);
+
+    const results = await webSearchTool.execute({ context: { query: 'wow', limit: 2 } } as any);
+
+    expect(results).toEqual([
+      { title: 'A', link: 'https://a.com', snippet: 'a' },
+      { title: 'B', link: 'https://b.com', snippet: 'b' },
+    ]);
+  });
+});

--- a/tests/tools/wowCharacterGearTool.test.ts
+++ b/tests/tools/wowCharacterGearTool.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { wowCharacterGearTool } from '../../src/mastra/tools';
+
+type FetchArgs = Parameters<typeof fetch>;
+
+const mockToken = 'fake-token';
+
+function jsonResponse(data: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  } as Response;
+}
+
+function textResponse(text: string, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    text: async () => text,
+    json: async () => JSON.parse(text),
+  } as Response;
+}
+
+describe('wowCharacterGearTool', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches character, spec, and equipment and returns normalized output', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (...args: FetchArgs) => {
+      const url = String(args[0]);
+      if (url.includes('/oauth/token')) {
+        return jsonResponse({ access_token: mockToken });
+      }
+      if (url.includes('/profile/wow/character/') && !url.includes('/specializations') && !url.includes('/equipment')) {
+        return jsonResponse({
+          name: 'Bezvoker',
+          realm: { name: 'Korgath' },
+          level: 80,
+          character_class: { name: 'Evoker' },
+          race: { name: 'Dracthyr' },
+          gender: { name: 'Female' },
+          guild: { name: 'Test Guild' },
+        });
+      }
+      if (url.includes('/specializations')) {
+        return jsonResponse({
+          active_specialization: { id: 1467, name: 'Devastation' },
+          active_hero_talent_tree: { id: 1, name: 'Scalecommander' },
+        });
+      }
+      if (url.includes('/data/wow/playable-specialization/')) {
+        return jsonResponse({ role: { type: 'dps' } });
+      }
+      if (url.includes('/equipment')) {
+        return jsonResponse({
+          equipped_items: [
+            { slot: { name: 'Head' }, name: 'Cowl of Tests', quality: { name: 'Epic' }, level: { value: 525 } },
+          ],
+        });
+      }
+      return textResponse('not found', false, 404);
+    });
+
+    const result = await wowCharacterGearTool.execute({ context: { characterName: 'bezvoker', serverName: 'korgath', region: 'us' } } as any);
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(result.name).toBe('Bezvoker');
+    expect(result.server).toBe('Korgath');
+    expect(result.spec).toBe('Devastation');
+    expect(result.role).toBe('dps');
+    expect(result.heroTalentTree).toEqual({ id: 1, name: 'Scalecommander' });
+    expect(result.gear).toEqual([
+      { slot: 'Head', name: 'Cowl of Tests', quality: 'Epic', itemLevel: 525 },
+    ]);
+  });
+
+  it('falls back to static role mapping when playable-specialization API fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (...args: FetchArgs) => {
+      const url = String(args[0]);
+      if (url.includes('/oauth/token')) return jsonResponse({ access_token: mockToken });
+      if (url.includes('/profile/wow/character/') && !url.includes('/specializations') && !url.includes('/equipment'))
+        return jsonResponse({ name: 'Bezvoker', realm: { name: 'Korgath' } });
+      if (url.includes('/specializations')) return jsonResponse({ active_specialization: { id: 66, name: 'Protection' } });
+      if (url.includes('/data/wow/playable-specialization/')) return textResponse('error', false, 500);
+      if (url.includes('/equipment')) return jsonResponse({ equipped_items: [] });
+      return textResponse('not found', false, 404);
+    });
+
+    const result = await wowCharacterGearTool.execute({ context: { characterName: 'bezvoker', serverName: 'korgath', region: 'us' } } as any);
+    expect(result.role).toBe('tank');
+  });
+});


### PR DESCRIPTION
- Add unit tests for wowCharacterGearTool, webSearchTool, fetchUrlContentTool, bisScraperTool
- Add mocked e2e agent test for basic character lookup (bezvoker on korgath)
- Introduce test setup (env defaults, log suppression)

No production code changes; external calls mocked for reliability.