### PR TITLE
Add Dockerfile and Kubernetes manifests for containerized deployment.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Dependencies
+node_modules
+
+# Builds
+.dist
+build
+dist
+
+# Tests and local artifacts
+tests
+coverage
+wow_gear_debug.log
+
+# VCS
+.git
+.gitignore
+
+# Docker context
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=22
+FROM node:${NODE_VERSION}-alpine AS runtime
+
+WORKDIR /app
+
+# Install only production deps
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Copy source
+COPY tsconfig.json ./
+COPY src ./src
+
+# Ensure non-root runtime
+RUN chown -R node:node /app
+USER node
+
+# Environment you will commonly set at runtime
+#   MODEL_PROVIDER=openai|ollama (default: openai)
+#   OPENAI_API_KEY=... (if MODEL_PROVIDER=openai)
+#   OPENAI_BASE_URL=... (optional)
+#   OPENAI_MODEL=gpt-4o (optional)
+#   OLLAMA_MODEL=llama3.1:latest (if MODEL_PROVIDER=ollama)
+#   DISCORD_ENABLED=true|false (enable Discord bot)
+#   DISCORD_BOT_TOKEN=... (if Discord enabled)
+#   DISCORD_CLIENT_ID=... (if Discord enabled)
+#   BRAVE_API_KEY=... (for web search MCP server)
+ENV NODE_ENV=production
+
+# For runtime, set working directory so that the app's relative
+# SQLite path (file:../../memory.db) resolves to /app/memory.db
+WORKDIR /app/src/mastra/agents
+
+# Default command runs the TypeScript entry via ts-node ESM loader
+CMD ["node", "--loader", "ts-node/esm", "../../src/mastra/index.ts"]

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sndai
+  labels:
+    app: sndai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sndai
+  template:
+    metadata:
+      labels:
+        app: sndai
+    spec:
+      containers:
+        - name: app
+          image: your-registry/sndai:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: MODEL_PROVIDER
+              value: "openai"   # or "ollama"
+            - name: DISCORD_ENABLED
+              value: "true"     # set "false" to disable Discord bot
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: sndai-secrets
+                  key: OPENAI_API_KEY
+            - name: BRAVE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: sndai-secrets
+                  key: BRAVE_API_KEY
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: sndai-secrets
+                  key: DISCORD_BOT_TOKEN
+            - name: DISCORD_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: sndai-secrets
+                  key: DISCORD_CLIENT_ID
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: false
+          volumeMounts:
+            - name: data
+              mountPath: /app
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: sndai-pvc

--- a/deploy/pvc.yaml
+++ b/deploy/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sndai-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/secret.example.yaml
+++ b/deploy/secret.example.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sndai-secrets
+  labels:
+    app: sndai
+type: Opaque
+stringData:
+  OPENAI_API_KEY: "REPLACE_ME"
+  BRAVE_API_KEY: "REPLACE_ME"
+  DISCORD_BOT_TOKEN: "REPLACE_ME"
+  DISCORD_CLIENT_ID: "REPLACE_ME"


### PR DESCRIPTION
- Container: Node 22-alpine, prod deps only, non-root, ts-node ESM
- Ensures SQLite memory.db path resolves and is persisted at /app
- K8s: Deployment (1 replica worker), PVC for /app, Secret example

Closes #19 