### PR TITLE
Add Helm chart for sndai with Secrets, optional Service/Ingress (NGIN…

### DIFF
--- a/charts/sndai/Chart.yaml
+++ b/charts/sndai/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: sndai
+version: 0.1.0
+description: Helm chart for sndai (WoW gear assistant)
+type: application
+appVersion: "1.0.0"

--- a/charts/sndai/README.md
+++ b/charts/sndai/README.md
@@ -1,0 +1,39 @@
+This chart deploys `sndai` (WoW gear assistant) with optional Discord bot, Secrets for sensitive env vars, optional Service and Ingress for HTTP exposure, and optional PVC for persisting the memory database.
+
+Quickstart:
+
+```sh
+# Render defaults
+helm template sndai ./charts/sndai
+
+# Install with secrets and discord disabled
+helm upgrade -i sndai ./charts/sndai \
+  --set image.repository=ghcr.io/YOUR_USER/sndai \
+  --set image.tag=latest \
+  --set secrets.OPENAI_API_KEY=sk-... \
+  --set secrets.BLIZZARD_CLIENT_ID=... \
+  --set secrets.BLIZZARD_CLIENT_SECRET=... \
+  --set secrets.BRAVE_API_KEY=... \
+  --set env.DISCORD_ENABLED="false"
+
+# If you want ingress (requires service)
+helm upgrade -i sndai ./charts/sndai \
+  --set service.enabled=true \
+  --set service.port=8080 \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.hosts[0].host=sndai.example.com \
+  --set ingress.hosts[0].paths[0].path=/ \
+  --set ingress.hosts[0].paths[0].pathType=Prefix
+
+# To persist memory.db
+helm upgrade -i sndai ./charts/sndai \
+  --set persistence.enabled=true \
+  --set persistence.size=1Gi
+```
+
+Notes:
+- Secrets are created from `values.yaml` keys under `secrets`. Leave them empty to skip, or pass via `--set` or a separate values file.
+- If you only run the Discord bot, you may not need a Service/Ingress. If you expose an HTTP endpoint later, enable Service and Ingress.
+- For NGINX ingress, set `ingress.className=nginx` (or rely on annotation `kubernetes.io/ingress.class: nginx`).
+- The container starts a Discord worker when `DISCORD_ENABLED="true"`. Ensure `DISCORD_BOT_TOKEN` and `DISCORD_CLIENT_ID` are provided.

--- a/charts/sndai/templates/_helpers.tpl
+++ b/charts/sndai/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{- define "sndai.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "sndai.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sndai.chart" -}}
+{{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end -}}

--- a/charts/sndai/templates/configmap.yaml
+++ b/charts/sndai/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sndai.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ include "sndai.name" . }}
+    helm.sh/chart: {{ include "sndai.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  {{- range $key, $val := .Values.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+  {{- range $key, $val := .Values.extraEnv }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/charts/sndai/templates/deployment.yaml
+++ b/charts/sndai/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sndai.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "sndai.name" . }}
+    helm.sh/chart: {{ include "sndai.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "sndai.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "sndai.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+      containers:
+        - name: sndai
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "sndai.fullname" . }}-config
+            - secretRef:
+                name: {{ include "sndai.fullname" . }}-secrets
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /app
+            {{- end }}
+          {{- if .Values.service.enabled }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "sndai.fullname" . }}
+        {{- end }}

--- a/charts/sndai/templates/ingress.yaml
+++ b/charts/sndai/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.ingress.enabled .Values.service.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sndai.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "sndai.name" . }}
+    helm.sh/chart: {{ include "sndai.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.className }}
+  annotations:
+    kubernetes.io/ingress.class: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "sndai.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/sndai/templates/pvc.yaml
+++ b/charts/sndai/templates/pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sndai.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "sndai.name" . }}
+    helm.sh/chart: {{ include "sndai.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes: {{ toYaml .Values.persistence.accessModes | nindent 2 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/sndai/templates/secret.yaml
+++ b/charts/sndai/templates/secret.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sndai.fullname" . }}-secrets
+  labels:
+    app.kubernetes.io/name: {{ include "sndai.name" . }}
+    helm.sh/chart: {{ include "sndai.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.secretAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{- if .Values.secrets.OPENAI_API_KEY }}
+  OPENAI_API_KEY: {{ .Values.secrets.OPENAI_API_KEY | quote }}
+  {{- end }}
+  {{- if .Values.secrets.BRAVE_API_KEY }}
+  BRAVE_API_KEY: {{ .Values.secrets.BRAVE_API_KEY | quote }}
+  {{- end }}
+  {{- if .Values.secrets.BLIZZARD_CLIENT_ID }}
+  BLIZZARD_CLIENT_ID: {{ .Values.secrets.BLIZZARD_CLIENT_ID | quote }}
+  {{- end }}
+  {{- if .Values.secrets.BLIZZARD_CLIENT_SECRET }}
+  BLIZZARD_CLIENT_SECRET: {{ .Values.secrets.BLIZZARD_CLIENT_SECRET | quote }}
+  {{- end }}
+  {{- if .Values.secrets.DISCORD_BOT_TOKEN }}
+  DISCORD_BOT_TOKEN: {{ .Values.secrets.DISCORD_BOT_TOKEN | quote }}
+  {{- end }}
+  {{- if .Values.secrets.DISCORD_CLIENT_ID }}
+  DISCORD_CLIENT_ID: {{ .Values.secrets.DISCORD_CLIENT_ID | quote }}
+  {{- end }}

--- a/charts/sndai/templates/service.yaml
+++ b/charts/sndai/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sndai.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "sndai.name" . }}
+    helm.sh/chart: {{ include "sndai.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "sndai.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+{{- end }}

--- a/charts/sndai/values.yaml
+++ b/charts/sndai/values.yaml
@@ -1,0 +1,76 @@
+# Default values for sndai.
+# Override these in a values file or via --set.
+
+image:
+  repository: your-registry/sndai
+  tag: latest
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext:
+  readOnlyRootFilesystem: false
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+service:
+  enabled: false
+  type: ClusterIP
+  port: 8080
+
+# Ingress for exposing a (future) HTTP endpoint. Disabled by default.
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+  hosts:
+    - host: sndai.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# Persistent volume to keep memory.db if desired
+persistence:
+  enabled: false
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  storageClassName: ""
+
+# Feature flags / env
+env:
+  # Core runtime
+  NODE_ENV: production
+  MODEL_PROVIDER: openai # or "ollama"
+  DISCORD_ENABLED: "false" # set to "true" to run discord bot
+  # Optional tuning
+  DISCORD_TEMPERATURE: "0.5"
+  OPENAI_MODEL: gpt-4o
+  OPENAI_BASE_URL: https://api.openai.com/v1
+  OLLAMA_MODEL: llama3.1:latest
+
+# Secret values (mounted as env from Secret)
+secrets:
+  OPENAI_API_KEY: ""
+  BRAVE_API_KEY: ""
+  BLIZZARD_CLIENT_ID: ""
+  BLIZZARD_CLIENT_SECRET: ""
+  DISCORD_BOT_TOKEN: ""
+  DISCORD_CLIENT_ID: ""
+
+# Extra environment variables as plain-text (ConfigMap)
+extraEnv: {}


### PR DESCRIPTION
…X), and PVC

Enables storing sensitive env (OpenAI, Blizzard, Brave, Discord) in a Secret, plain env in ConfigMap, and feature flags via values. Supports optional Service and NGINX Ingress, plus PVC to persist memory.db.