### PR TITLE
changing default max messages to be lesser context

### DIFF
--- a/MEMORY_CONFIGURATION.md
+++ b/MEMORY_CONFIGURATION.md
@@ -22,8 +22,8 @@ Your agent now has three complementary memory layers that work together:
 ### Basic Memory Settings
 
 ```bash
-# Number of recent messages to include in context (default: 40)
-MEMORY_MAX_MESSAGES=40
+# Number of recent messages to include in context (default: 10)
+MEMORY_MAX_MESSAGES=10
 ```
 
 ### Semantic Recall Configuration
@@ -148,7 +148,7 @@ MEMORY_WORKING_MEMORY_ENABLED=true
 # Reduce semantic search overhead
 MEMORY_SEMANTIC_RECALL_TOP_K=3
 MEMORY_SEMANTIC_RECALL_MESSAGE_RANGE=2
-MEMORY_MAX_MESSAGES=20
+MEMORY_MAX_MESSAGES=10
 ```
 
 ### Thread-Isolated Configuration
@@ -184,7 +184,7 @@ MEMORY_WORKING_MEMORY_SCOPE=resource
 ### Optimization Tips
 
 - Use `MEMORY_SEMANTIC_RECALL_TOP_K=3` for faster responses
-- Set `MEMORY_MAX_MESSAGES=20` if conversation history is sufficient
+- Set `MEMORY_MAX_MESSAGES=10` if conversation history is sufficient
 - Consider `MEMORY_SEMANTIC_RECALL_SCOPE=thread` for high-traffic scenarios
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This project is the official AI-powered agent for the **Stand and Deliver** guil
   - `DISCORD_TEMPERATURE` (optional; default: `0.5`)
 - Agent behavior (optional)
   - `AGENT_MAX_STEPS` (optional; maximum number of execution steps for the agent, defaults to no limit)
-  - `MEMORY_MAX_MESSAGES` (optional; maximum number of messages to remember per thread, defaults to `40`)
+  - `MEMORY_MAX_MESSAGES` (optional; maximum number of messages to remember per thread, defaults to `10`)
 
 3. (Optional) If using a custom memory DB location, update `src/mastra/storage.ts` (defaults to `memory.db` in the repo root).
 
@@ -143,7 +143,7 @@ await wowCharacterGearAgent.generate("...", {
 
 Environment variables:
 
-- `MEMORY_MAX_MESSAGES`: number of recent messages to include (default: `40`)
+- `MEMORY_MAX_MESSAGES`: number of recent messages to include (default: `10`)
 - `MEMORY_SEMANTIC_RECALL_ENABLED`: enable/disable semantic recall (default: `true`)
 - `MEMORY_SEMANTIC_RECALL_TOP_K`: number of similar messages to retrieve (default: `5`)
 - `MEMORY_SEMANTIC_RECALL_MESSAGE_RANGE`: surrounding messages per match (default: `3`)
@@ -156,7 +156,7 @@ Example `.env` snippet:
 
 ```env
 # Basic history
-MEMORY_MAX_MESSAGES=40
+MEMORY_MAX_MESSAGES=10
 
 # Semantic recall
 MEMORY_SEMANTIC_RECALL_ENABLED=true

--- a/src/mastra/agents/index.ts
+++ b/src/mastra/agents/index.ts
@@ -10,7 +10,7 @@ import { wowCharacterGearTool, webSearchTool, fetchUrlContentTool } from '../too
 import { bisScraperTool } from '../tools/bisTool';
 
 // Get memory configuration from environment variables
-const memoryMaxMessages = process.env.MEMORY_MAX_MESSAGES ? parseInt(process.env.MEMORY_MAX_MESSAGES, 10) : 40;
+const memoryMaxMessages = process.env.MEMORY_MAX_MESSAGES ? parseInt(process.env.MEMORY_MAX_MESSAGES, 10) : 10;
 
 // Memory configuration from environment variables
 const semanticRecallEnabled = process.env.MEMORY_SEMANTIC_RECALL_ENABLED !== 'false';


### PR DESCRIPTION
This pull request updates the default value for the `MEMORY_MAX_MESSAGES` configuration across documentation and code, reducing it from 40 to 10. This change ensures consistency in how many recent messages are kept in memory, impacting both agent behavior and user guidance.

**Configuration and Code Updates:**

* Changed the default value of `MEMORY_MAX_MESSAGES` from 40 to 10 in the memory configuration logic in `src/mastra/agents/index.ts`.

**Documentation Updates:**

* Updated all references to the default value of `MEMORY_MAX_MESSAGES` from 40 to 10 in `README.md`, including environment variable descriptions, example `.env` snippets, and setup instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R58) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R146) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L159-R159)
* Updated the default and recommended values for `MEMORY_MAX_MESSAGES` in `MEMORY_CONFIGURATION.md` in all relevant sections, including basic settings, semantic recall, and optimization tips. [[1]](diffhunk://#diff-fab93c3952d1ee1f3eaaeee2e87336479236ff9910a4f5caa262c5276d97b153L25-R26) [[2]](diffhunk://#diff-fab93c3952d1ee1f3eaaeee2e87336479236ff9910a4f5caa262c5276d97b153L151-R151) [[3]](diffhunk://#diff-fab93c3952d1ee1f3eaaeee2e87336479236ff9910a4f5caa262c5276d97b153L187-R187)