### PR TITLE
updating version to 1.0.5

### DIFF
--- a/charts/sndai/Chart.yaml
+++ b/charts/sndai/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sndai
-version: 0.1.0
+version: 0.1.1
 description: Helm chart for sndai (WoW gear assistant)
 type: application
-appVersion: "1.0.0"
+appVersion: "1.0.5"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sndai:
-    image: bezerker/sndai:v1.0.4
+    image: bezerker/sndai:v1.0.5
     env_file:
       - .env
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sndai",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sndai",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sndai",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request updates the version of the `sndai` application across multiple deployment and configuration files to ensure consistency and to release the latest changes (v1.0.5).

Version updates:

* Updated the version in `package.json` to `1.0.5` to reflect the new release.
* Updated the `docker-compose.yml` file to use the new Docker image tag `v1.0.5` for the `sndai` service.
* Updated the Helm chart in `charts/sndai/Chart.yaml` to version `0.1.1` and set `appVersion` to `1.0.5` for deployment consistency.