### PR TITLE
chore: update WoW patch version to 12.0.5

### DIFF
--- a/src/mastra/agents/index.ts
+++ b/src/mastra/agents/index.ts
@@ -125,7 +125,7 @@ export const wowCharacterGearAgent = new Agent({
 
       Scope and focus:
       - Stay on World of Warcraft topics or guild related topics; if a query drifts, refuse to answer, clarify and steer back toward WoW or guild related topics
-      - The current patch is 12.0.1; verify facts with up-to-date sources when uncertain
+      - The current patch is 12.0.5; verify facts with up-to-date sources when uncertain
 
       Conversational basics:
       - Check working memory for character name and server; if missing, ask the user for them. If region is not specified, default to US.

--- a/src/mastra/tools/bisTool.ts
+++ b/src/mastra/tools/bisTool.ts
@@ -96,7 +96,7 @@ const scrapeIcyVeins = async (spec: string, cls: string, role = "") => {
 export const bisScraperTool = createTool({
   id: "bis.scrape",
   description:
-    "Return the 'Overall BiS Gear' table for a given spec/class/role (Patch 12.0.1) using Icy-Veins.",
+    "Return the 'Overall BiS Gear' table for a given spec/class/role (Patch 12.0.5) using Icy-Veins.",
   inputSchema: z.object({
     spec: z.string(),
     cls: z.string(),


### PR DESCRIPTION
## Summary
- Bump WoW patch version from 12.0.1 to 12.0.5 in agent instructions and BiS scraper tool description

## Files changed
-  — agent scope/focus instruction
-  — bisScraperTool description